### PR TITLE
Show Feeling Rating in Detail View

### DIFF
--- a/thought-record/Controllers/RecordDetailViewController.swift
+++ b/thought-record/Controllers/RecordDetailViewController.swift
@@ -52,7 +52,8 @@ extension RecordDetailViewController {
     private func feelingsArrayToString(array: [Feeling]) -> String {
         var feelingNames: [String] = []
         for feeling in array {
-            feelingNames.append(feeling.name)
+            let feelingString = "\(feeling.name) (\(feeling.rating))"
+            feelingNames.append(feelingString)
         }
         let feelingListString = feelingNames.joined(separator: ", ")
         return feelingListString


### PR DESCRIPTION
## What:
Showing feeling rating as well as name in detail view.
## Why:
Trello: [Show feeling rating # on detail view](https://trello.com/c/d0kEgpbS)
## How:
Modifying `feelingsArrayToString()` to include rating property as well as name property.
## Screenshots:
**Before:**
<img width="237" alt="screen shot 2018-10-15 at 1 31 28 pm" src="https://user-images.githubusercontent.com/5642098/46967663-3a292880-d07f-11e8-9222-4c64003c540b.png">
**After:**
<img width="285" alt="screen shot 2018-10-15 at 1 33 09 pm" src="https://user-images.githubusercontent.com/5642098/46967671-3f867300-d07f-11e8-962c-b46c7110ac13.png">
