### PR TITLE
Suggest feeling

### DIFF
--- a/thought-record.xcodeproj/project.pbxproj
+++ b/thought-record.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1E76B5B36914940203B1F85D /* Pods_thought_record.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90ABD5CEBD5D4067793359BF /* Pods_thought_record.framework */; };
 		432208992174D5720080FCFD /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432208982174D5720080FCFD /* Constants.swift */; };
 		4335BD4F2176860B00DA24CC /* AddRecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4335BD4E2176860B00DA24CC /* AddRecordViewController.swift */; };
+		43473F16217789FA0067F97C /* Tone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43473F15217789FA0067F97C /* Tone.swift */; };
+		43473F1821778B440067F97C /* ExpandedTones.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43473F1721778B440067F97C /* ExpandedTones.swift */; };
 		434C05B2216E328A000CD1B6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434C05B1216E328A000CD1B6 /* AppDelegate.swift */; };
 		434C05B4216E328A000CD1B6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434C05B3216E328A000CD1B6 /* ViewController.swift */; };
 		434C05B9216E328B000CD1B6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 434C05B8216E328B000CD1B6 /* Assets.xcassets */; };
@@ -29,6 +31,8 @@
 /* Begin PBXFileReference section */
 		432208982174D5720080FCFD /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		4335BD4E2176860B00DA24CC /* AddRecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRecordViewController.swift; sourceTree = "<group>"; };
+		43473F15217789FA0067F97C /* Tone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tone.swift; sourceTree = "<group>"; };
+		43473F1721778B440067F97C /* ExpandedTones.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedTones.swift; sourceTree = "<group>"; };
 		434C05AE216E328A000CD1B6 /* thought-record.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "thought-record.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		434C05B1216E328A000CD1B6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		434C05B3216E328A000CD1B6 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -101,7 +105,9 @@
 				434C05E5216E4F1C000CD1B6 /* Tag.swift */,
 				43657700216E51E100F54479 /* TemporaryData.swift */,
 				4365778E216FDEC400F54479 /* SegueIdentifier.swift */,
+				43473F15217789FA0067F97C /* Tone.swift */,
 				432208982174D5720080FCFD /* Constants.swift */,
+				43473F1721778B440067F97C /* ExpandedTones.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -274,10 +280,12 @@
 				434C05D6216E48A9000CD1B6 /* TabBarViewController.swift in Sources */,
 				434C05B2216E328A000CD1B6 /* AppDelegate.swift in Sources */,
 				432208992174D5720080FCFD /* Constants.swift in Sources */,
+				43473F1821778B440067F97C /* ExpandedTones.swift in Sources */,
 				434C05E4216E4DD7000CD1B6 /* Feeling.swift in Sources */,
 				4335BD4F2176860B00DA24CC /* AddRecordViewController.swift in Sources */,
 				434C05E0216E4A8C000CD1B6 /* AllRecordsViewController.swift in Sources */,
 				434C05E2216E4D91000CD1B6 /* ThoughtRecord.swift in Sources */,
+				43473F16217789FA0067F97C /* Tone.swift in Sources */,
 				43657701216E51E100F54479 /* TemporaryData.swift in Sources */,
 				434C05DC216E4A49000CD1B6 /* HomeViewController.swift in Sources */,
 			);

--- a/thought-record/Controllers/AddRecordViewController.swift
+++ b/thought-record/Controllers/AddRecordViewController.swift
@@ -63,7 +63,6 @@ class AddRecordViewController: UIViewController {
     
     @IBAction func suggestButtonTapped(_ sender: UIButton) {
         checkTone(of: generateToneString())
-        populateSuggestionField()
     }
     
     @IBAction func save() {
@@ -164,7 +163,6 @@ extension AddRecordViewController {
         let unhelpfulThoughtsText = unhelpfulThoughtsView.text!
         
         let toneString = "\(thoughtText) \(unhelpfulThoughtsText)"
-        print(toneString)
         return toneString
     }
     
@@ -173,7 +171,11 @@ extension AddRecordViewController {
             print(error)
         }) { (response) in
             //print(response)
-            self.toneName = self.getToneName(from: response)
+            DispatchQueue.main.async {
+                self.toneName = self.getToneName(from: response)
+                self.populateSuggestionField(with: self.toneName)
+            }
+            
             
             //print(response.documentTone.tones?[0].toneName ?? "no suggestion")
         }
@@ -188,10 +190,8 @@ extension AddRecordViewController {
         }
     }
     
-    func populateSuggestionField() {
-        if toneName != "" {
-            beforeFeelingField.text = toneName
-        }
+    func populateSuggestionField(with text: String) {
+            beforeFeelingField.text = text
     }
     
 }

--- a/thought-record/Controllers/AddRecordViewController.swift
+++ b/thought-record/Controllers/AddRecordViewController.swift
@@ -172,7 +172,7 @@ extension AddRecordViewController {
         }) { (response) in
             DispatchQueue.main.async {
                 self.toneID = self.getToneID(from: response)
-                self.populateSuggestionField(with: self.toneID)
+                self.populateSuggestionField(with: self.getExpandedFeelingName(from: self.toneID))
             }
         }
     }
@@ -183,6 +183,21 @@ extension AddRecordViewController {
         }
         else {
             return "no suggestion"
+        }
+    }
+    
+    func getExpandedFeelingName(from toneID: String) -> String {
+        let expandedTones = ExpandedTones()
+        
+        switch toneID {
+        case Tone.anger.rawValue: return expandedTones.angerTones.randomElement() ?? "angry"
+        case Tone.fear.rawValue: return expandedTones.fearTones.randomElement() ?? "afraid"
+        case Tone.joy.rawValue: return expandedTones.joyTones.randomElement() ?? "joyful"
+        case Tone.sadness.rawValue: return expandedTones.sadnessTones.randomElement() ?? "sad"
+        case Tone.analytical.rawValue: return expandedTones.analyticalTones.randomElement() ?? "analytical"
+        case Tone.confident.rawValue: return expandedTones.confidentTones.randomElement() ?? "confident"
+        case Tone.tentative.rawValue: return expandedTones.tentativeTones.randomElement() ?? "tentative"
+        default: return "sorry, no suggestion"
         }
     }
     

--- a/thought-record/Controllers/AddRecordViewController.swift
+++ b/thought-record/Controllers/AddRecordViewController.swift
@@ -158,8 +158,9 @@ extension AddRecordViewController {
 extension AddRecordViewController {
     
     func generateToneString() -> String {
-        let thoughtText = thoughtField.text
-        let unhelpfulThoughtsText = unhelpfulThoughtsView.text
+        let thoughtText = thoughtField.text!
+        let unhelpfulThoughtsText = unhelpfulThoughtsView.text!
+        
         let toneString = "\(thoughtText) \(unhelpfulThoughtsText)"
         print(toneString)
         return toneString

--- a/thought-record/Controllers/AddRecordViewController.swift
+++ b/thought-record/Controllers/AddRecordViewController.swift
@@ -60,6 +60,10 @@ class AddRecordViewController: UIViewController {
         showDatePickerActionSheet()
     }
     
+    @IBAction func suggestButtonTapped(_ sender: UIButton) {
+        checkTone(of: generateToneString())
+    }
+    
     @IBAction func save() {
         guard let newRecord = createNewRecord() else { navigationController?.popViewController(animated: true); return }
         
@@ -153,9 +157,15 @@ extension AddRecordViewController {
 
 extension AddRecordViewController {
     
-    func checkTone() {
-        let text = "I'm so happy this finally works! :D"
-        
+    func generateToneString() -> String {
+        let thoughtText = thoughtField.text
+        let unhelpfulThoughtsText = unhelpfulThoughtsView.text
+        let toneString = "\(thoughtText) \(unhelpfulThoughtsText)"
+        print(toneString)
+        return toneString
+    }
+    
+    func checkTone(of text: String) {
         toneAnalyzer.tone(toneContent: ToneContent.text(text), sentences: false, tones: nil, contentLanguage: nil, acceptLanguage: nil, headers: nil, failure: { (error) in
             print(error)
         }) { (response) in

--- a/thought-record/Controllers/AddRecordViewController.swift
+++ b/thought-record/Controllers/AddRecordViewController.swift
@@ -42,6 +42,7 @@ class AddRecordViewController: UIViewController {
     
     var newRecord: ThoughtRecord?
     weak var delegate: AddRecordViewControllerDelegate?
+    var toneName = ""
     
     // MARK: Lifecycle Methods
 
@@ -62,6 +63,7 @@ class AddRecordViewController: UIViewController {
     
     @IBAction func suggestButtonTapped(_ sender: UIButton) {
         checkTone(of: generateToneString())
+        populateSuggestionField()
     }
     
     @IBAction func save() {
@@ -166,21 +168,29 @@ extension AddRecordViewController {
         return toneString
     }
     
-    func checkTone(of text: String) {
+    func checkTone(of text: String)  {
         toneAnalyzer.tone(toneContent: ToneContent.text(text), sentences: false, tones: nil, contentLanguage: nil, acceptLanguage: nil, headers: nil, failure: { (error) in
             print(error)
         }) { (response) in
-            print(response)
-            
-            if response.documentTone.tones != nil {
-                if let toneName = response.documentTone.tones?[0].toneName {
-                    print(toneName)
-                } else {
-                    print("no suggestion")
-                }
-            }
+            //print(response)
+            self.toneName = self.getToneName(from: response)
             
             //print(response.documentTone.tones?[0].toneName ?? "no suggestion")
+        }
+    }
+    
+    func getToneName(from analysis: ToneAnalysis) -> String {
+        if let toneName = analysis.documentTone.tones?[0].toneName {
+            return toneName
+        }
+        else {
+            return "no suggestion"
+        }
+    }
+    
+    func populateSuggestionField() {
+        if toneName != "" {
+            beforeFeelingField.text = toneName
         }
     }
     

--- a/thought-record/Controllers/AddRecordViewController.swift
+++ b/thought-record/Controllers/AddRecordViewController.swift
@@ -42,7 +42,7 @@ class AddRecordViewController: UIViewController {
     
     var newRecord: ThoughtRecord?
     weak var delegate: AddRecordViewControllerDelegate?
-    var toneName = ""
+    var toneID = ""
     
     // MARK: Lifecycle Methods
 
@@ -170,20 +170,16 @@ extension AddRecordViewController {
         toneAnalyzer.tone(toneContent: ToneContent.text(text), sentences: false, tones: nil, contentLanguage: nil, acceptLanguage: nil, headers: nil, failure: { (error) in
             print(error)
         }) { (response) in
-            //print(response)
             DispatchQueue.main.async {
-                self.toneName = self.getToneName(from: response)
-                self.populateSuggestionField(with: self.toneName)
+                self.toneID = self.getToneID(from: response)
+                self.populateSuggestionField(with: self.toneID)
             }
-            
-            
-            //print(response.documentTone.tones?[0].toneName ?? "no suggestion")
         }
     }
     
-    func getToneName(from analysis: ToneAnalysis) -> String {
-        if let toneName = analysis.documentTone.tones?[0].toneName {
-            return toneName
+    func getToneID(from analysis: ToneAnalysis) -> String {
+        if let toneID = analysis.documentTone.tones?[0].toneID {
+            return toneID
         }
         else {
             return "no suggestion"

--- a/thought-record/Models/ExpandedTones.swift
+++ b/thought-record/Models/ExpandedTones.swift
@@ -1,0 +1,21 @@
+//
+//  ExpandedTones.swift
+//  thought-record
+//
+//  Created by DetroitLabs on 10/17/18.
+//  Copyright © 2018 DetroitLabs. All rights reserved.
+//
+
+import Foundation
+
+struct ExpandedTones {
+    
+    var angerTones = ["frustrated", "annoyed", "angry"]
+    var fearTones = ["concerned", "alarmed", "afraid"]
+    var joyTones = ["happy", "joyful"]
+    var sadnessTones = ["sad"]
+    var analyticalTones = ["analytical", "rational"]
+    var confidentTones = ["confident", "strong", "sure"]
+    var tentativeTones = ["uncertain", "confused", "tentative"]
+    
+}

--- a/thought-record/Models/ExpandedTones.swift
+++ b/thought-record/Models/ExpandedTones.swift
@@ -12,9 +12,9 @@ struct ExpandedTones {
     
     var angerTones = ["frustrated", "annoyed", "angry"]
     var fearTones = ["concerned", "alarmed", "afraid"]
-    var joyTones = ["happy", "joyful"]
-    var sadnessTones = ["sad"]
-    var analyticalTones = ["analytical", "rational"]
+    var joyTones = ["happy", "joyful", "content"]
+    var sadnessTones = ["sad", "gloomy", "glum"]
+    var analyticalTones = ["analytical", "thoughtful"]
     var confidentTones = ["confident", "strong", "sure"]
     var tentativeTones = ["uncertain", "confused", "tentative"]
     

--- a/thought-record/Models/Tone.swift
+++ b/thought-record/Models/Tone.swift
@@ -7,3 +7,13 @@
 //
 
 import Foundation
+
+enum Tone: String {
+    case anger = "anger"
+    case fear = "fear"
+    case joy = "joy"
+    case sadness = "sadness"
+    case analytical = "analytical"
+    case confident = "confident"
+    case tentative = "tentative"
+}

--- a/thought-record/Models/Tone.swift
+++ b/thought-record/Models/Tone.swift
@@ -1,0 +1,9 @@
+//
+//  Tone.swift
+//  thought-record
+//
+//  Created by DetroitLabs on 10/17/18.
+//  Copyright © 2018 DetroitLabs. All rights reserved.
+//
+
+import Foundation

--- a/thought-record/Views/Main.storyboard
+++ b/thought-record/Views/Main.storyboard
@@ -417,11 +417,11 @@
             <objects>
                 <viewController id="wOg-JH-a4l" customClass="AddRecordViewController" customModule="thought_record" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="a3i-uO-x76">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="1267"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="1867"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CjV-LP-0NQ">
-                                <rect key="frame" x="0.0" y="64" width="375" height="1110"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="1710"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="tSY-hK-70R">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1371.5"/>
@@ -700,7 +700,7 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
-                    <size key="freeformSize" width="375" height="1267"/>
+                    <size key="freeformSize" width="375" height="1867"/>
                     <connections>
                         <outlet property="afterFeelingField" destination="y8k-E2-oQV" id="QsE-Bf-4iB"/>
                         <outlet property="afterFeelingRatingLabel" destination="B0w-cC-dUs" id="L15-QQ-ZdK"/>

--- a/thought-record/Views/Main.storyboard
+++ b/thought-record/Views/Main.storyboard
@@ -424,7 +424,7 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="1110"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="tSY-hK-70R">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1333.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1371.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="UMu-OP-Tat" userLabel="Title Stack View">
                                                 <rect key="frame" x="30" y="30" width="315" height="31.5"/>
@@ -484,7 +484,7 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="6ek-Kf-cuR" userLabel="Initial Feeling Stack View">
-                                                <rect key="frame" x="30" y="287" width="315" height="251.5"/>
+                                                <rect key="frame" x="30" y="287" width="315" height="289.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How are you feeling?" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A2l-Nj-jsf">
                                                         <rect key="frame" x="0.0" y="0.0" width="315" height="20.5"/>
@@ -539,10 +539,17 @@
                                                             </label>
                                                         </subviews>
                                                     </stackView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L8X-AP-baI">
+                                                        <rect key="frame" x="0.0" y="259.5" width="315" height="30"/>
+                                                        <state key="normal" title="Suggest"/>
+                                                        <connections>
+                                                            <action selector="suggestButtonTapped:" destination="wOg-JH-a4l" eventType="touchUpInside" id="sC6-KR-FEx"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="uR1-QZ-eXP" userLabel="Facts Stack View">
-                                                <rect key="frame" x="30" y="568.5" width="315" height="349.5"/>
+                                                <rect key="frame" x="30" y="606.5" width="315" height="349.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The Facts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a1l-aY-GlZ">
                                                         <rect key="frame" x="0.0" y="0.0" width="315" height="20.5"/>
@@ -583,7 +590,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="pml-mk-82t" userLabel="Unpacking Stack View">
-                                                <rect key="frame" x="30" y="948" width="315" height="305"/>
+                                                <rect key="frame" x="30" y="986" width="315" height="305"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unpacking The Thought" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HnA-fe-LzJ">
                                                         <rect key="frame" x="0.0" y="0.0" width="315" height="20.5"/>
@@ -650,7 +657,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="Rlw-e4-awI">
-                                                <rect key="frame" x="30" y="1283" width="315" height="20.5"/>
+                                                <rect key="frame" x="30" y="1321" width="315" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Great job!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VbY-qD-gLd">
                                                         <rect key="frame" x="120" y="0.0" width="75.5" height="20.5"/>


### PR DESCRIPTION
## What:
- When use has input text and pressed "Suggest," the beforeFeeling field will be populated with a suggested feeling based on the API response
## Why:
- Trello: [Show Suggested Feeling to User](https://trello.com/c/pbIXBnT7)
## How:
- New "Suggest" button
- New methods: `getToneID()` & `getExpandedFeelingName()`
- New enum, `Tone`, of possible ToneID responses from API
- New struct, `ExpandedTones`, of arrays of possible feelings based on ToneID
- Updated `checkTone()` method to asynchronously call `getToneID()` and `populateSuggestionField` after getting response
## Notes:
- This only goes on the before feeling for now. Adding it for the after feeling can be a "nice to have."
- When we have settings, Suggest button should disappear for users who do not want to use suggestion feature.
- Might consider only displaying suggestions w/ certain degree of probability based on score from API.
