### PR TITLE
Settings screen

### DIFF
--- a/thought-record.xcodeproj/project.pbxproj
+++ b/thought-record.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4335BD4F2176860B00DA24CC /* AddRecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4335BD4E2176860B00DA24CC /* AddRecordViewController.swift */; };
 		43473F16217789FA0067F97C /* Tone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43473F15217789FA0067F97C /* Tone.swift */; };
 		43473F1821778B440067F97C /* ExpandedTones.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43473F1721778B440067F97C /* ExpandedTones.swift */; };
+		43473F1C2177AE260067F97C /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43473F1B2177AE260067F97C /* Settings.swift */; };
 		434C05B2216E328A000CD1B6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434C05B1216E328A000CD1B6 /* AppDelegate.swift */; };
 		434C05B4216E328A000CD1B6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434C05B3216E328A000CD1B6 /* ViewController.swift */; };
 		434C05B9216E328B000CD1B6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 434C05B8216E328B000CD1B6 /* Assets.xcassets */; };
@@ -33,6 +34,7 @@
 		4335BD4E2176860B00DA24CC /* AddRecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRecordViewController.swift; sourceTree = "<group>"; };
 		43473F15217789FA0067F97C /* Tone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tone.swift; sourceTree = "<group>"; };
 		43473F1721778B440067F97C /* ExpandedTones.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedTones.swift; sourceTree = "<group>"; };
+		43473F1B2177AE260067F97C /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		434C05AE216E328A000CD1B6 /* thought-record.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "thought-record.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		434C05B1216E328A000CD1B6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		434C05B3216E328A000CD1B6 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -100,14 +102,15 @@
 		434C05C3216E3CDA000CD1B6 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				434C05E1216E4D91000CD1B6 /* ThoughtRecord.swift */,
-				434C05E3216E4DD7000CD1B6 /* Feeling.swift */,
-				434C05E5216E4F1C000CD1B6 /* Tag.swift */,
-				43657700216E51E100F54479 /* TemporaryData.swift */,
-				4365778E216FDEC400F54479 /* SegueIdentifier.swift */,
-				43473F15217789FA0067F97C /* Tone.swift */,
 				432208982174D5720080FCFD /* Constants.swift */,
 				43473F1721778B440067F97C /* ExpandedTones.swift */,
+				434C05E3216E4DD7000CD1B6 /* Feeling.swift */,
+				4365778E216FDEC400F54479 /* SegueIdentifier.swift */,
+				43473F1B2177AE260067F97C /* Settings.swift */,
+				434C05E5216E4F1C000CD1B6 /* Tag.swift */,
+				43657700216E51E100F54479 /* TemporaryData.swift */,
+				434C05E1216E4D91000CD1B6 /* ThoughtRecord.swift */,
+				43473F15217789FA0067F97C /* Tone.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -283,6 +286,7 @@
 				43473F1821778B440067F97C /* ExpandedTones.swift in Sources */,
 				434C05E4216E4DD7000CD1B6 /* Feeling.swift in Sources */,
 				4335BD4F2176860B00DA24CC /* AddRecordViewController.swift in Sources */,
+				43473F1C2177AE260067F97C /* Settings.swift in Sources */,
 				434C05E0216E4A8C000CD1B6 /* AllRecordsViewController.swift in Sources */,
 				434C05E2216E4D91000CD1B6 /* ThoughtRecord.swift in Sources */,
 				43473F16217789FA0067F97C /* Tone.swift in Sources */,

--- a/thought-record.xcodeproj/project.pbxproj
+++ b/thought-record.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		43473F16217789FA0067F97C /* Tone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43473F15217789FA0067F97C /* Tone.swift */; };
 		43473F1821778B440067F97C /* ExpandedTones.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43473F1721778B440067F97C /* ExpandedTones.swift */; };
 		43473F1C2177AE260067F97C /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43473F1B2177AE260067F97C /* Settings.swift */; };
+		43473F202177AFF20067F97C /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43473F1F2177AFF20067F97C /* SettingsViewController.swift */; };
 		434C05B2216E328A000CD1B6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434C05B1216E328A000CD1B6 /* AppDelegate.swift */; };
 		434C05B4216E328A000CD1B6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434C05B3216E328A000CD1B6 /* ViewController.swift */; };
 		434C05B9216E328B000CD1B6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 434C05B8216E328B000CD1B6 /* Assets.xcassets */; };
@@ -35,6 +36,7 @@
 		43473F15217789FA0067F97C /* Tone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tone.swift; sourceTree = "<group>"; };
 		43473F1721778B440067F97C /* ExpandedTones.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedTones.swift; sourceTree = "<group>"; };
 		43473F1B2177AE260067F97C /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
+		43473F1F2177AFF20067F97C /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		434C05AE216E328A000CD1B6 /* thought-record.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "thought-record.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		434C05B1216E328A000CD1B6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		434C05B3216E328A000CD1B6 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 				434C05DF216E4A8C000CD1B6 /* AllRecordsViewController.swift */,
 				43657702216E85C000F54479 /* RecordDetailViewController.swift */,
 				4335BD4E2176860B00DA24CC /* AddRecordViewController.swift */,
+				43473F1F2177AFF20067F97C /* SettingsViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				4335BD4F2176860B00DA24CC /* AddRecordViewController.swift in Sources */,
 				43473F1C2177AE260067F97C /* Settings.swift in Sources */,
 				434C05E0216E4A8C000CD1B6 /* AllRecordsViewController.swift in Sources */,
+				43473F202177AFF20067F97C /* SettingsViewController.swift in Sources */,
 				434C05E2216E4D91000CD1B6 /* ThoughtRecord.swift in Sources */,
 				43473F16217789FA0067F97C /* Tone.swift in Sources */,
 				43657701216E51E100F54479 /* TemporaryData.swift in Sources */,

--- a/thought-record/Controllers/AddRecordViewController.swift
+++ b/thought-record/Controllers/AddRecordViewController.swift
@@ -26,6 +26,7 @@ class AddRecordViewController: UIViewController {
     @IBOutlet weak var beforeFeelingField: UITextField!
     @IBOutlet weak var beforeFeelingSlider: UISlider!
     @IBOutlet weak var beforeFeelingRatingLabel: UILabel!
+    @IBOutlet weak var suggestButton: UIButton!
     
     @IBOutlet weak var factsSupportingView: UITextView!
     @IBOutlet weak var factsAgainstView: UITextView!
@@ -45,10 +46,11 @@ class AddRecordViewController: UIViewController {
     var toneID = ""
     
     // MARK: Lifecycle Methods
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setDateButtonText(date: Date())
+        showOrHideSuggestButton()
     }
 
     // MARK: Actions
@@ -150,6 +152,16 @@ extension AddRecordViewController {
             newDate = formattedShortDate(date: Date())
         }
         return newDate
+    }
+    
+    func showOrHideSuggestButton() {
+        print(userSettings.allowTextAnalysis)
+        if userSettings.allowTextAnalysis == false {
+            suggestButton.isHidden = true
+        }
+        else {
+            suggestButton.isHidden = false
+        }
     }
     
 }

--- a/thought-record/Controllers/SettingsViewController.swift
+++ b/thought-record/Controllers/SettingsViewController.swift
@@ -11,27 +11,20 @@ import UIKit
 class SettingsViewController: UITableViewController {
     
     let settingOptions = ["Allow Text Analysis"]
-
+    var userSettingForAnalysis: Bool = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         useLargeTitles()
-
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem
     }
 
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
         return 1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
         return settingOptions.count
     }
 
@@ -46,50 +39,10 @@ class SettingsViewController: UITableViewController {
     func useLargeTitles() {
         navigationController?.navigationBar.prefersLargeTitles = true
     }
-
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
+    
+    @IBAction func analysisSettingSwitchChanged(_ sender: UISwitch) {
+        userSettingForAnalysis = sender.isOn
     }
-    */
-
-    /*
-    // Override to support editing the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            // Delete the row from the data source
-            tableView.deleteRows(at: [indexPath], with: .fade)
-        } else if editingStyle == .insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }    
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
+    
 
 }

--- a/thought-record/Controllers/SettingsViewController.swift
+++ b/thought-record/Controllers/SettingsViewController.swift
@@ -1,0 +1,90 @@
+//
+//  SettingsViewController.swift
+//  thought-record
+//
+//  Created by DetroitLabs on 10/17/18.
+//  Copyright © 2018 DetroitLabs. All rights reserved.
+//
+
+import UIKit
+
+class SettingsViewController: UITableViewController {
+    
+    let settingOptions = ["Allow Text Analysis"]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return settingOptions.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "SettingCell", for: indexPath)
+
+        cell.textLabel?.text = settingOptions[indexPath.row]
+
+        return cell
+    }
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/thought-record/Controllers/SettingsViewController.swift
+++ b/thought-record/Controllers/SettingsViewController.swift
@@ -11,7 +11,6 @@ import UIKit
 class SettingsViewController: UITableViewController {
     
     let settingOptions = ["Allow Text Analysis"]
-    var userSettingForAnalysis: Bool = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,7 +40,7 @@ class SettingsViewController: UITableViewController {
     }
     
     @IBAction func analysisSettingSwitchChanged(_ sender: UISwitch) {
-        userSettingForAnalysis = sender.isOn
+        userSettings.allowTextAnalysis = sender.isOn
     }
     
 

--- a/thought-record/Controllers/SettingsViewController.swift
+++ b/thought-record/Controllers/SettingsViewController.swift
@@ -14,6 +14,7 @@ class SettingsViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        useLargeTitles()
 
         // Uncomment the following line to preserve selection between presentations
         // self.clearsSelectionOnViewWillAppear = false
@@ -40,6 +41,10 @@ class SettingsViewController: UITableViewController {
         cell.textLabel?.text = settingOptions[indexPath.row]
 
         return cell
+    }
+    
+    func useLargeTitles() {
+        navigationController?.navigationBar.prefersLargeTitles = true
     }
 
     /*

--- a/thought-record/Models/Settings.swift
+++ b/thought-record/Models/Settings.swift
@@ -10,4 +10,10 @@ import Foundation
 
 class Settings: Codable {
     var allowTextAnalysis: Bool
+    
+    init (allowTextAnalysis: Bool) {
+        self.allowTextAnalysis = allowTextAnalysis
+    }
 }
+
+let userSettings = Settings(allowTextAnalysis: false)

--- a/thought-record/Models/Settings.swift
+++ b/thought-record/Models/Settings.swift
@@ -1,0 +1,13 @@
+//
+//  Settings.swift
+//  thought-record
+//
+//  Created by DetroitLabs on 10/17/18.
+//  Copyright © 2018 DetroitLabs. All rights reserved.
+//
+
+import Foundation
+
+class Settings: Codable {
+    var allowTextAnalysis: Bool
+}

--- a/thought-record/Models/Settings.swift
+++ b/thought-record/Models/Settings.swift
@@ -16,4 +16,4 @@ class Settings: Codable {
     }
 }
 
-let userSettings = Settings(allowTextAnalysis: false)
+let userSettings = Settings(allowTextAnalysis: true)

--- a/thought-record/Views/Main.storyboard
+++ b/thought-record/Views/Main.storyboard
@@ -25,6 +25,15 @@
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gaT-XT-J5h" id="jff-2Z-akM">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="c3e-DC-Evk">
+                                            <rect key="frame" x="317" y="6.5" width="51" height="31"/>
+                                        </switch>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="c3e-DC-Evk" secondAttribute="trailing" constant="9" id="KrO-lm-wWw"/>
+                                        <constraint firstItem="c3e-DC-Evk" firstAttribute="centerY" secondItem="jff-2Z-akM" secondAttribute="centerY" id="tUY-HP-qJZ"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>
@@ -33,12 +42,12 @@
                             <outlet property="delegate" destination="62s-y5-KSo" id="c0i-Be-rGt"/>
                         </connections>
                     </tableView>
-                    <tabBarItem key="tabBarItem" title="Settings" id="A06-mw-OhB"/>
+                    <navigationItem key="navigationItem" title="Settings" id="0Vg-Wy-1bu"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lEI-xF-LHN" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-390" y="791"/>
+            <point key="canvasLocation" x="548" y="790.25487256371821"/>
         </scene>
         <!--All Thought Records-->
         <scene sceneID="bF7-OI-8Qr">
@@ -720,7 +729,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RGR-jP-ksn" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1015" y="1213"/>
+            <point key="canvasLocation" x="1952.8" y="1212.1439280359821"/>
         </scene>
         <!--Tab Bar View Controller-->
         <scene sceneID="Q9Z-AI-qZu">
@@ -734,7 +743,7 @@
                     <connections>
                         <segue destination="Ee6-0D-aDv" kind="relationship" relationship="viewControllers" id="ROW-fr-gdf"/>
                         <segue destination="1V8-0j-nl0" kind="relationship" relationship="viewControllers" id="dhz-VZ-n6F"/>
-                        <segue destination="62s-y5-KSo" kind="relationship" relationship="viewControllers" id="uTf-1d-ghT"/>
+                        <segue destination="zoG-py-yhh" kind="relationship" relationship="viewControllers" id="uTf-1d-ghT"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W56-gr-VfW" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -759,6 +768,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HYs-fs-IWF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="76" y="73.313343328335833"/>
+        </scene>
+        <!--Settings-->
+        <scene sceneID="EaD-ML-FNk">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="zoG-py-yhh" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Settings" id="A06-mw-OhB"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="uvX-bH-6OO">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="62s-y5-KSo" kind="relationship" relationship="rootViewController" id="ZBF-C2-so0"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xp6-ot-5Xd" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-391.19999999999999" y="790.25487256371821"/>
         </scene>
     </scenes>
 </document>

--- a/thought-record/Views/Main.storyboard
+++ b/thought-record/Views/Main.storyboard
@@ -13,13 +13,13 @@
         <!--Settings-->
         <scene sceneID="Fi9-sQ-Whg">
             <objects>
-                <tableViewController id="62s-y5-KSo" sceneMemberID="viewController">
+                <tableViewController id="62s-y5-KSo" customClass="SettingsViewController" customModule="thought_record" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Dnc-Z1-AmY">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="gaT-XT-J5h">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingCell" id="gaT-XT-J5h">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gaT-XT-J5h" id="jff-2Z-akM">

--- a/thought-record/Views/Main.storyboard
+++ b/thought-record/Views/Main.storyboard
@@ -28,6 +28,9 @@
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="c3e-DC-Evk">
                                             <rect key="frame" x="317" y="6.5" width="51" height="31"/>
+                                            <connections>
+                                                <action selector="analysisSettingSwitchChanged:" destination="62s-y5-KSo" eventType="valueChanged" id="zhR-yt-YKq"/>
+                                            </connections>
                                         </switch>
                                     </subviews>
                                     <constraints>

--- a/thought-record/Views/Main.storyboard
+++ b/thought-record/Views/Main.storyboard
@@ -26,7 +26,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="c3e-DC-Evk">
+                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c3e-DC-Evk">
                                             <rect key="frame" x="317" y="6.5" width="51" height="31"/>
                                             <connections>
                                                 <action selector="analysisSettingSwitchChanged:" destination="62s-y5-KSo" eventType="valueChanged" id="zhR-yt-YKq"/>

--- a/thought-record/Views/Main.storyboard
+++ b/thought-record/Views/Main.storyboard
@@ -725,6 +725,7 @@
                         <outlet property="factsAgainstView" destination="blL-hs-9y2" id="9SZ-1r-99g"/>
                         <outlet property="factsSupportingView" destination="2Ro-5I-Cap" id="Xa2-22-jc6"/>
                         <outlet property="situationField" destination="Zed-vL-AWl" id="jSm-SM-A8u"/>
+                        <outlet property="suggestButton" destination="L8X-AP-baI" id="Xsp-XU-J9W"/>
                         <outlet property="tagsField" destination="vQE-nn-CxE" id="FX6-dg-vaO"/>
                         <outlet property="thoughtField" destination="UtU-oa-8Aa" id="Cwj-9i-62C"/>
                         <outlet property="unhelpfulThoughtsView" destination="Yif-ja-KwI" id="Nx1-Ys-qbD"/>
@@ -732,7 +733,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RGR-jP-ksn" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1952.8" y="1212.1439280359821"/>
+            <point key="canvasLocation" x="1828" y="1485"/>
         </scene>
         <!--Tab Bar View Controller-->
         <scene sceneID="Q9Z-AI-qZu">


### PR DESCRIPTION
## What:
- Adding rows to Settings screen to allow user to switch between allowing & disallowing text analysis
## Why:
- Trello: [Settings Screen](https://trello.com/c/meScqUVa)
- Any API integrations should have user consent
## How:
- New `Settings` class and `userSettings` instance
- Creating settings table view with one setting option and one switch
- Updating user setting for allowing text analysis based on switch state
- Conditionally displaying Suggest button on Add Record screen based on user setting
## Note:
- There are more possible settings in the future noted on the Trello card.
## Screenshots:
![simulator screen shot - iphone xr - 2018-10-17 at 14 38 24](https://user-images.githubusercontent.com/5642098/47108697-53b2a780-d21a-11e8-855c-8f4f54f21ef0.png)
