### PR TITLE
Update data model to use Date object instead of String

### DIFF
--- a/thought-record/Controllers/AddRecordViewController.swift
+++ b/thought-record/Controllers/AddRecordViewController.swift
@@ -44,7 +44,6 @@ class AddRecordViewController: UIViewController {
     var newRecord: ThoughtRecord?
     weak var delegate: AddRecordViewControllerDelegate?
     var toneID = ""
-    var userChoseNewDate = false
     var userChosenDate = Date()
     
     // MARK: Lifecycle Methods
@@ -117,7 +116,6 @@ extension AddRecordViewController {
         let dateChosen = UIAlertAction(title: "Done", style: .default) { action in
             let newDate = datePicker.date
             self.setDateButtonText(date: newDate)
-            self.userChoseNewDate = true
             self.userChosenDate = newDate
         }
         
@@ -147,23 +145,6 @@ extension AddRecordViewController {
         
         return newRecord
     }
-    
-//    private func createNewRecordDate() -> Date {
-//        var newDate: Date
-////        if let dateOfEntry = dateButton.titleLabel?.text {
-////            newDate = dateOfEntry
-////        } else {
-////            newDate = formattedShortDate(date: Date())
-////        }
-//
-//        if userChoseNewDate {
-//            newDate = userChosenDate
-//        }
-//        else {
-//            newDate = Date()
-//        }
-//        return newDate
-//    }
     
     func showOrHideSuggestButton() {
         print(userSettings.allowTextAnalysis)

--- a/thought-record/Controllers/AddRecordViewController.swift
+++ b/thought-record/Controllers/AddRecordViewController.swift
@@ -44,6 +44,8 @@ class AddRecordViewController: UIViewController {
     var newRecord: ThoughtRecord?
     weak var delegate: AddRecordViewControllerDelegate?
     var toneID = ""
+    var userChoseNewDate = false
+    var userChosenDate = Date()
     
     // MARK: Lifecycle Methods
     
@@ -115,6 +117,8 @@ extension AddRecordViewController {
         let dateChosen = UIAlertAction(title: "Done", style: .default) { action in
             let newDate = datePicker.date
             self.setDateButtonText(date: newDate)
+            self.userChoseNewDate = true
+            self.userChosenDate = newDate
         }
         
         datePickerAlert.addAction(dateChosen)
@@ -139,20 +143,27 @@ extension AddRecordViewController {
             let newBalancedPerspective = balancedPerspectiveView.text else { return nil }
         
         
-        newRecord = ThoughtRecord(date: createNewRecordDate(), thought: newThought, situation: newSituation, feelingsStart: [newFeelingBefore], unhelpfulThoughts: newUnhelpfulThoughts, factsSupporting: newFactsSupporting, factsAgainst: newFactsAgainst, balancedPerspective: newBalancedPerspective, feelingsEnd: [newFeelingAfter], tags: [newTag])
+        newRecord = ThoughtRecord(date: userChosenDate, thought: newThought, situation: newSituation, feelingsStart: [newFeelingBefore], unhelpfulThoughts: newUnhelpfulThoughts, factsSupporting: newFactsSupporting, factsAgainst: newFactsAgainst, balancedPerspective: newBalancedPerspective, feelingsEnd: [newFeelingAfter], tags: [newTag])
         
         return newRecord
     }
     
-    private func createNewRecordDate() -> String {
-        var newDate: String
-        if let dateOfEntry = dateButton.titleLabel?.text {
-            newDate = dateOfEntry
-        } else {
-            newDate = formattedShortDate(date: Date())
-        }
-        return newDate
-    }
+//    private func createNewRecordDate() -> Date {
+//        var newDate: Date
+////        if let dateOfEntry = dateButton.titleLabel?.text {
+////            newDate = dateOfEntry
+////        } else {
+////            newDate = formattedShortDate(date: Date())
+////        }
+//
+//        if userChoseNewDate {
+//            newDate = userChosenDate
+//        }
+//        else {
+//            newDate = Date()
+//        }
+//        return newDate
+//    }
     
     func showOrHideSuggestButton() {
         print(userSettings.allowTextAnalysis)

--- a/thought-record/Controllers/AllRecordsViewController.swift
+++ b/thought-record/Controllers/AllRecordsViewController.swift
@@ -35,7 +35,7 @@ extension AllRecordsViewController {
     
     func setCellTitle(recordAtPath: ThoughtRecord) -> String {
         let title = recordAtPath.thought
-        let date = recordAtPath.date
+        let date = recordAtPath.shortDate
         return "\(date): \(title)"
     }
     

--- a/thought-record/Controllers/HomeViewController.swift
+++ b/thought-record/Controllers/HomeViewController.swift
@@ -45,7 +45,7 @@ extension HomeViewController {
     }
     
     private func updateTimeLabel() {
-        if let lastTime = lastRecord?.date {
+        if let lastTime = lastRecord?.longDate {
             timeLabel.text = "Your last check-in was on \(lastTime)."
         } else {
             timeLabel.text = "Nice to see you again!"

--- a/thought-record/Controllers/RecordDetailViewController.swift
+++ b/thought-record/Controllers/RecordDetailViewController.swift
@@ -70,7 +70,7 @@ extension RecordDetailViewController {
     
     private func displayRecordData() {
         if let record = recordToShow {
-            dateLabel.text = "Date: \(record.date)"
+            dateLabel.text = "Date: \(record.longDate)"
             thoughtLabel.text = "Thought: \(record.thought)"
             situationLabel.text = "Situation: \(record.situation)"
             feelingsStartLabel.text = "Feelings at time: \(feelingsArrayToString(array: record.feelingsStart))"

--- a/thought-record/Models/TemporaryData.swift
+++ b/thought-record/Models/TemporaryData.swift
@@ -33,7 +33,7 @@ class TagDatabase {
 class ThoughtRecordDatabase {
     
     var thoughts = [
-        ThoughtRecord(date: "October 10",
+        ThoughtRecord(date: Date(),
                       thought: "I'm never going to finish my capstone! It's too much.",
                       situation: "Working on capstone",
                       feelingsStart: [FeelingDatabase().feelings[1], FeelingDatabase().feelings[3]],
@@ -44,7 +44,7 @@ class ThoughtRecordDatabase {
                       feelingsEnd: [FeelingDatabase().feelings[0]],
                       tags: [TagDatabase().tags[0]]
     ),
-        ThoughtRecord(date: "October 9",
+        ThoughtRecord(date: Date(),
                       thought: "I'm out sick so I'm going to forget everything I ever learned about coding",
                       situation: "home sick from work",
                       feelingsStart: [FeelingDatabase().feelings[0]],

--- a/thought-record/Models/ThoughtRecord.swift
+++ b/thought-record/Models/ThoughtRecord.swift
@@ -36,4 +36,23 @@ class ThoughtRecord: Codable {
         self.tags = tags
     }
     
+    var shortDate: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MMM dd, yyyy"
+        
+        let dateString = dateFormatter.string(from: date)
+        let formattedDate = dateFormatter.date(from: dateString)
+        
+        return dateFormatter.string(from: formattedDate!)
+    }
+    
+    var longDate: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MMM dd, yyyy"
+        
+        let dateString = dateFormatter.string(from: date)
+        let formattedDate = dateFormatter.date(from: dateString)
+        
+        return dateFormatter.string(from: formattedDate!)
+    }
 }

--- a/thought-record/Models/ThoughtRecord.swift
+++ b/thought-record/Models/ThoughtRecord.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class ThoughtRecord: Codable {
     
-    var date: String
+    var date: Date
     var thought: String
     var situation: String
     
@@ -23,7 +23,7 @@ class ThoughtRecord: Codable {
     
     var tags: [Tag]
     
-    init(date: String, thought: String, situation: String, feelingsStart: [Feeling], unhelpfulThoughts: String, factsSupporting: String, factsAgainst:String, balancedPerspective: String, feelingsEnd: [Feeling], tags: [Tag]) {
+    init(date: Date, thought: String, situation: String, feelingsStart: [Feeling], unhelpfulThoughts: String, factsSupporting: String, factsAgainst:String, balancedPerspective: String, feelingsEnd: [Feeling], tags: [Tag]) {
         self.date = date
         self.thought = thought
         self.situation = situation


### PR DESCRIPTION
## What:
- What it says in the title :)
## Why:
- So we can keep all of the date information, display it differently in different places, and eventually perhaps do math & stuff on it
## How:
- Updating data model, then updating everywhere using the old property
- Two new computed properties: `shortDate` and `longDate` take care of formatting the Date, so anywhere we have access to a Thought Record we can easily choose which format will work best 
