### PR TITLE
Fix crash when API doesn't suggest a tone

### DIFF
--- a/thought-record/Controllers/RecordDetailViewController.swift
+++ b/thought-record/Controllers/RecordDetailViewController.swift
@@ -367,7 +367,7 @@ extension RecordDetailViewController {
             print(error)
         }) { (response) in
             DispatchQueue.main.async {
-                guard let tone = self.getTone(from: response) else { return }
+                guard let tone = self.getTone(from: response) else { self.populateSuggestionField(with: "no suggestion, try again"); return }
                 self.tone = tone
                 self.populateSuggestionField(with: tone.getExpandedTones().randomElement()!)
             }
@@ -375,6 +375,8 @@ extension RecordDetailViewController {
     }
     
     private func getTone(from analysis: ToneAnalysis) -> Tone? {
+        guard let tonesReturned = analysis.documentTone.tones else { return nil }
+        if tonesReturned.count < 1 { return nil }
         if let toneID = analysis.documentTone.tones?[0].toneID {
             return Tone(rawValue: toneID)
         }


### PR DESCRIPTION
## What:
- The app was crashing if the API didn't give back suggested tones
- Now instead of crashing, it tells the user "no suggestion, try again"
## Why:
- Crashes are bad, telling user what's up is good
- Also don't want to crash during demo 🙃
## How:
- Changes to `getTone()` and `checkTone()` methods to guard against empty tone array